### PR TITLE
[fix/#49] QuerySet을 딕셔너리 접근이 가능하도록 변환

### DIFF
--- a/pullrequest/views.py
+++ b/pullrequest/views.py
@@ -106,6 +106,6 @@ class PRReviewCategoryStatisticsView(APIView):
         if not queryset:
             return success_response({"statistics": {}})
 
-        review_mode_count = queryset.values('review_mode').annotate(count=Count('review_mode')).order_by('-count')
+        review_mode_count = list(queryset.values('review_mode').annotate(count=Count('review_mode')).order_by('-count'))
 
         return success_response({"statistics": {item['review_mode']: item['count'] for item in review_mode_count}})


### PR DESCRIPTION
## 📖개요
<br>
PRReviewCategoryStatisticsView() 에서 Django ORM이 반환한 QuerySet 구조를 딕셔너리에 맞게 변환
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #49 
<br>
<br>

## 💻작업사항
- QuerySet을 list()로 명시적 변환하여 딕셔너리 접근이 가능하도록 함
<br>



## 💡작성한 이슈 외에 작업한 사항
-
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?